### PR TITLE
Support for CommandBox env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 modules
+*.project
+settings.xml
+.settings

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -2,8 +2,8 @@ component {
 
 	function configure() {
 		settings = {
-			fileName = '.env',
-			printOnLoad = false
+			'fileName' = '.env',
+			'printOnLoad' = false
 		};
 
 		interceptors = [

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -3,7 +3,8 @@ component {
 	function configure() {
 		settings = {
 			'fileName' = '.env',
-			'printOnLoad' = false
+			'printOnLoad' = false,
+			'verbose' = false
 		};
 
 		interceptors = [

--- a/README.md
+++ b/README.md
@@ -14,9 +14,17 @@ This package loads up local files as Java Properties for both CommandBox command
 
 > Another good tip is to create an `.env.example` file that **is source controlled** that contains all the keys required in your `.env` file but none of the values.
 
-#### CommandBox Commands
+#### CommandBox Startup
 
-When loading up the CLI, this package will look for a `.env` file in the directory where CommandBox is being loaded or executed.  If found it will take the key / value pairs found in the file and store them as CommandBox environment variables.  These values are now available in any CommandBox command either using `systemSettings.getSystemSetting( name, defaultValue )`, or by using CommandBox's [built-in system variable expansion.](https://commandbox.ortusbooks.com/usage/system-settings#using-system-settings-from-the-cli)
+When loading up the CLI, this package will look for a `.env` file in the directory where CommandBox is being loaded or executed.  If found it will take the key / value pairs found in the file and store them as CommandBox environment variables.  These values are now available in any CommandBox command either using `systemSettings.getSystemSetting( name, defaultValue )`, or by using CommandBox's [built-in system variable expansion.](https://commandbox.ortusbooks.com/usage/system-settings#using-system-settings-from-the-cli):
+
+```bash
+echo ${myvar}
+```
+
+#### CommandBox Commands
+Any time you run a command, if there is a `.env` file in the current working directory where the command was run, those vars will be loaded into the environment context of that command only.   This is great for localized variables that only apply to a specific project. Note, this feature only kicks in if you are on CommandBox 4.5 or higher.  
+
 
 #### CommandBox Servers
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ This package loads up local files as Java Properties for both CommandBox command
 
 #### CommandBox Commands
 
-When loading up the CLI, this package will look for a `.env` file in the directory where CommandBox is being loaded or executed.  If found it will take the key / value pairs found in the file and store them as Java properties.  These values are now available in any CommandBox command either using the `java.lang.System` object and the `getProperties()` or `getProperty(name, defaultValue)` methods (Note: the keys are case-sensitive), or by using CommandBox's [built-in system variable expansion.](https://commandbox.ortusbooks.com/content/usage/execution/system-settings.html)
-
-Since the CommandBox properties are loaded on CLI start, you will need to `reload` CommandBox before seeing any changes to the `.env` file.  This can be accomplished just by running `reload` from the interactive shell.  If you are running one-off commands, this happens on each command for you already.
+When loading up the CLI, this package will look for a `.env` file in the directory where CommandBox is being loaded or executed.  If found it will take the key / value pairs found in the file and store them as CommandBox environment variables.  These values are now available in any CommandBox command either using `systemSettings.getSystemSetting( name, defaultValue )`, or by using CommandBox's [built-in system variable expansion.](https://commandbox.ortusbooks.com/usage/system-settings#using-system-settings-from-the-cli)
 
 #### CommandBox Servers
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,21 @@ There is currently no way to provide a per-project override.
 
 #### Logging Properties
 
-Properties and values can be logged to the console for debugging by setting the `printOnLoad` setting to `true`.
+There are two levels of logging available.  You can log to the console every time an `.env` file has been loaded by setting the `printOnLoad` setting to `true`.
 
 ```
 config set modules.commandbox-dotenv.printOnLoad=true
 ```
+
+You can get further output that shows you the name and value of every variable that was loaded by setting the `verbse` setting to `true` as well.
+
+
+```
+config set modules.commandbox-dotenv.verbose=true
+```
+
+The `verbse` setting will only kick in if `printOnLoad` is also true.
+
 
 ## Contributors
 

--- a/interceptors/LoadEnvForCommands.cfc
+++ b/interceptors/LoadEnvForCommands.cfc
@@ -12,7 +12,7 @@ component {
         }
         
         // Load env vars into CLI
-        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
+        envFileService.loadEnvToCLI( envStruct );
     }
 
     function preCommandParamProcess( interceptData ) {
@@ -23,7 +23,7 @@ component {
         }
         
         // Load env vars into CLI
-        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
+        envFileService.loadEnvToCLI( envStruct );
     }
 
 }

--- a/interceptors/LoadEnvForCommands.cfc
+++ b/interceptors/LoadEnvForCommands.cfc
@@ -1,24 +1,29 @@
 component {
-
-    property name="envFileName" inject="commandbox:moduleSettings:commandbox-dotenv:fileName";
-    property name="printOnLoad" inject="commandbox:moduleSettings:commandbox-dotenv:printOnLoad";
+    property name="moduleSettings" inject="commandbox:moduleSettings:commandbox-dotenv";
     property name="envFileService" inject="EnvironmentFileService@commandbox-dotenv";
-    property name="javaSystem" inject="java:java.lang.System";
     property name="fileSystemUtil" inject="FileSystem";
     property name='consoleLogger' inject='logbox:logger:console';
 
     function onCLIStart( interceptData ) {
         var directory = fileSystemUtil.resolvePath( "" );
-        var envStruct = envFileService.getEnvStruct( "#directory#/#envFileName#" );
-        if( !structIsEmpty( envStruct ) ) {
-            consoleLogger.info( "commandbox-dotenv: Loading Java properties from #directory##envFileName#" );
+        var envStruct = envFileService.getEnvStruct( "#directory#/#moduleSettings.fileName#" );
+        if( !structIsEmpty( envStruct ) && moduleSettings.printOnLoad ) {
+            consoleLogger.info( "commandbox-dotenv: Loading Java properties from #directory##moduleSettings.fileName#" );
         }
-        for (var key in envStruct) {
-            javaSystem.setProperty( key, envStruct[ key ] );
-            if( printOnLoad ) {
-                consoleLogger.info( "commandbox-dotenv: #key#=#envStruct[ key ]#" );
-            }
+        
+        // Load env vars into CLI
+        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
+    }
+
+    function preCommandParamProcess( interceptData ) {
+        var directory = fileSystemUtil.resolvePath( "" );
+        var envStruct = envFileService.getEnvStruct( "#directory#/#moduleSettings.fileName#" );
+        if( !structIsEmpty( envStruct ) && moduleSettings.printOnLoad ) {
+            consoleLogger.info( "commandbox-dotenv: Loading Java properties from #directory##moduleSettings.fileName#" );
         }
+        
+        // Load env vars into CLI
+        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
     }
 
 }

--- a/interceptors/LoadEnvForServers.cfc
+++ b/interceptors/LoadEnvForServers.cfc
@@ -1,14 +1,13 @@
 component {
-
-    property name="envFileName" inject="commandbox:moduleSettings:commandbox-dotenv:fileName";
+    property name="moduleSettings" inject="commandbox:moduleSettings:commandbox-dotenv";
     property name="envFileService" inject="EnvironmentFileService@commandbox-dotenv";
     property name='consoleLogger' inject='logbox:logger:console';
 
     function onServerStart(interceptData) {
         var webRoot = interceptData.serverInfo.webRoot;
-        var envStruct = envFileService.getEnvStruct( "#webRoot#/#envFileName#" );
-        if( !structIsEmpty( envStruct ) ) {
-            consoleLogger.info( "commandbox-dotenv: Setting server JVM arguments from #webRoot##envFileName#" );
+        var envStruct = envFileService.getEnvStruct( "#webRoot#/#moduleSettings.fileName#" );
+        if( !structIsEmpty( envStruct ) && moduleSettings.printOnLoad ) {
+            consoleLogger.info( "commandbox-dotenv: Setting server JVM arguments from #webRoot##moduleSettings.fileName#" );
         }
         for (var key in envStruct) {
             // Append to the JVM args

--- a/interceptors/LoadEnvPreServers.cfc
+++ b/interceptors/LoadEnvPreServers.cfc
@@ -1,23 +1,17 @@
 component {
-
-    property name="envFileName" inject="commandbox:moduleSettings:commandbox-dotenv:fileName";
-    property name="printOnLoad" inject="commandbox:moduleSettings:commandbox-dotenv:printOnLoad";
+    property name="moduleSettings" inject="commandbox:moduleSettings:commandbox-dotenv";
     property name="envFileService" inject="EnvironmentFileService@commandbox-dotenv";
-    property name="javaSystem" inject="java:java.lang.System";
     property name='consoleLogger' inject='logbox:logger:console';
 
     function preServerStart(interceptData) {
         var webRoot = interceptData.serverDetails.serverInfo.webRoot;
-        var envStruct = envFileService.getEnvStruct( "#webRoot#/#envFileName#" );
-        if( !structIsEmpty( envStruct ) ) {
-            consoleLogger.info( "commandbox-dotenv: Loading Java properties from #webRoot##envFileName#" );
+        var envStruct = envFileService.getEnvStruct( "#webRoot#/#moduleSettings.fileName#" );
+        if( !structIsEmpty( envStruct ) && moduleSettings.printOnLoad ) {
+            consoleLogger.info( "commandbox-dotenv: Loading Java properties from #webRoot##moduleSettings.fileName#" );
         }
-        for (var key in envStruct) {
-            javaSystem.setProperty( key, envStruct[ key ] );
-            if( printOnLoad ) {
-                consoleLogger.info( "commandbox-dotenv: #key#=#envStruct[ key ]#" );
-            }
-        }
+        
+        // Load env vars into CLI
+        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
     }
 
 }

--- a/interceptors/LoadEnvPreServers.cfc
+++ b/interceptors/LoadEnvPreServers.cfc
@@ -11,7 +11,7 @@ component {
         }
         
         // Load env vars into CLI
-        envFileService.loadEnvToCLI( envStruct, moduleSettings.printOnLoad );
+        envFileService.loadEnvToCLI( envStruct );
     }
 
 }

--- a/models/EnvironmentFileService.cfc
+++ b/models/EnvironmentFileService.cfc
@@ -4,6 +4,9 @@
 component singleton="true" {
 
     property name="propertyFile" inject="provider:PropertyFile@propertyFile";
+    property name='consoleLogger' inject='logbox:logger:console';
+    property name='systemSettings' inject='systemSettings';
+    property name="javaSystem" inject="java:java.lang.System";
 
     public function getEnvStruct( envFilePath ) {
         if ( ! fileExists( envFilePath ) ) {
@@ -18,6 +21,25 @@ component singleton="true" {
         return propertyFile.get()
             .load( envFilePath )
             .getAsStruct();
+    }
+    
+    public function loadEnvToCLI( required struct envStruct, printOnLoad=false ) {
+    	
+        for (var key in envStruct) {
+        	
+        	// Shim for older versions of CommandBox
+        	if( !structKeyExists( systemSettings, 'setSystemSetting' ) ) {
+            	javaSystem.setProperty( key, envStruct[ key ] );
+        	} else {
+ 				systemSettings.setSystemSetting( key, envStruct[ key ] );       		        		
+        	}
+            
+            if( printOnLoad ) {
+                consoleLogger.info( "commandbox-dotenv: #key#=#envStruct[ key ]#" );
+            }
+            
+        }
+        
     }
 
 }

--- a/models/EnvironmentFileService.cfc
+++ b/models/EnvironmentFileService.cfc
@@ -7,6 +7,7 @@ component singleton="true" {
     property name='consoleLogger' inject='logbox:logger:console';
     property name='systemSettings' inject='systemSettings';
     property name="javaSystem" inject="java:java.lang.System";
+    property name="moduleSettings" inject="commandbox:moduleSettings:commandbox-dotenv";
 
     public function getEnvStruct( envFilePath ) {
         if ( ! fileExists( envFilePath ) ) {
@@ -23,7 +24,7 @@ component singleton="true" {
             .getAsStruct();
     }
     
-    public function loadEnvToCLI( required struct envStruct, printOnLoad=false ) {
+    public function loadEnvToCLI( required struct envStruct ) {
     	
         for (var key in envStruct) {
         	
@@ -34,7 +35,7 @@ component singleton="true" {
 				systemSettings.setSystemSetting( key, envStruct[ key ] );       		        		
         	}
             
-            if( printOnLoad ) {
+            if( moduleSettings.printOnLoad && moduleSettings.verbose ) {
                 consoleLogger.info( "commandbox-dotenv: #key#=#envStruct[ key ]#" );
             }
             

--- a/models/EnvironmentFileService.cfc
+++ b/models/EnvironmentFileService.cfc
@@ -29,9 +29,9 @@ component singleton="true" {
         	
         	// Shim for older versions of CommandBox
         	if( !structKeyExists( systemSettings, 'setSystemSetting' ) ) {
-            	javaSystem.setProperty( key, envStruct[ key ] );
+				javaSystem.setProperty( key, envStruct[ key ] );
         	} else {
- 				systemSettings.setSystemSetting( key, envStruct[ key ] );       		        		
+				systemSettings.setSystemSetting( key, envStruct[ key ] );       		        		
         	}
             
             if( printOnLoad ) {


### PR DESCRIPTION
Includes the following changes

* Casing of module settings which appears in tab complete of "config set" command
* Inject entire module settings struct so moduel setting changes at runtime take immediate effect
* printOnLoad controls all debugging output
* Fixed broken link in readme
* listen to new preCommandParamProcess interception point in CommandBox 4.5 to load env vars before every command into that command's environment context only.
* New service method to encapsulte, and make reusable, the logic for loading env vars into the CLI instance.

This module wil fall back to doing nothing (much) new on current versions of CommandBox, but new features will automatically take affect once the user upgrades to CommandBox 4.5.