### PR TITLE
Stop server jvm args

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -7,7 +7,8 @@ component {
 			"globalEnvFile" = "~/.box.env",
 			"printOnLoad" = false,
 			"verbose" = false,
-			"checkEnvPreServerStart" = true
+			"checkEnvPreServerStart" = true,
+			"legacyLoadToServerJVMArgs" = true
 		};
 
 		interceptors = [

--- a/interceptors/LoadEnvForServers.cfc
+++ b/interceptors/LoadEnvForServers.cfc
@@ -4,6 +4,11 @@ component {
     property name='consoleLogger' inject='logbox:logger:console';
 
     function onServerStart( interceptData ) {
+    	
+    	if( !moduleSettings.legacyLoadToServerJVMArgs ) {
+    		return;
+    	}
+    	
         var webRoot = interceptData.serverInfo.webRoot;
         var envStruct = envFileService.getEnvStruct( "#webRoot#/#moduleSettings.fileName#" );
         if( !structIsEmpty( envStruct ) && moduleSettings.printOnLoad ) {

--- a/models/EnvironmentFileService.cfc
+++ b/models/EnvironmentFileService.cfc
@@ -8,6 +8,8 @@ component singleton="true" {
     property name='systemSettings' inject='systemSettings';
     property name="javaSystem" inject="java:java.lang.System";
     property name="moduleSettings" inject="commandbox:moduleSettings:commandbox-dotenv";
+    
+    this.NOT_EXISTS='______NOT_EXISTS______';
 
     public function getEnvStruct( envFilePath ) {
         if ( ! fileExists( envFilePath ) ) {
@@ -57,7 +59,8 @@ component singleton="true" {
 
     public array function diff( required struct source, required struct target ) {
         return arguments.source.reduce( ( acc, key ) => {
-            if ( ! target.keyExists( arguments.key ) ) {
+        	// If the key isn't in the target file AND isn't defined in the current environment already
+            if ( ! target.keyExists( arguments.key ) && systemSettings.getSystemSetting( arguments.key, this.NOT_EXISTS ) == this.NOT_EXISTS ) {
                 arguments.acc.append( arguments.key );
             }
             return arguments.acc;


### PR DESCRIPTION
There are two changes in this pull

* provide new module setting (`legacyLoadToServerJVMArgs`) to stop loading env vars into JVM args
* Improve `checkEnvPreServerStart` check to ignore env vars already set in the current shell's context via another means